### PR TITLE
fix: allow parent() on parent()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,7 @@
-declare module "mongoose-lean-virtuals" {
-    import mongoose = require('mongoose');
-    export default function mongooseLeanVirtuals(schema: mongoose.Schema<any, any, any, any>, opts?: any): void;
-    export function mongooseLeanVirtuals(schema: mongoose.Schema<any, any, any, any>, opts?: any): void;
-  }
+import { Schema } from "mongoose";
+export const mongooseLeanVirtuals: {
+  (schema: Schema, opts?: any): void;
+  parent: (value: any) => any;
+};
+
+export default mongooseLeanVirtuals;

--- a/index.js
+++ b/index.js
@@ -76,8 +76,8 @@ function attachVirtuals(schema, res, virtuals, parent) {
     }
   }
 
-  applyVirtualsToChildren(this, schema, res, virtualsForChildren, parent);
   addToParentMap(res, parent);
+  applyVirtualsToChildren(this, schema, res, virtualsForChildren, parent);
   return applyVirtualsToResult(schema, res, toApply);
 }
 


### PR DESCRIPTION
I also fixed the index.d.ts to also export the `parent()` definition.

Fix #65.
Possibly fix #64.