### PR TITLE
fix: allow calling `parent()` on parent, allow accessing parent's virtual from child subdoc

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,7 @@
 declare module "mongoose-lean-virtuals" {
-    import mongoose = require('mongoose');
-    export default function mongooseLeanVirtuals(schema: mongoose.Schema<any, any, any, any>, opts?: any): void;
-    export function mongooseLeanVirtuals(schema: mongoose.Schema<any, any, any, any>, opts?: any): void;
-  }
+  import mongoose = require('mongoose');
+  export default function mongooseLeanVirtuals(schema: mongoose.Schema<any, any, any, any>, opts?: any): void;
+  export function mongooseLeanVirtuals(schema: mongoose.Schema<any, any, any, any>, opts?: any): void;
+
+  export function parent(value: any): any;
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "acquit-ignore": "0.1.0",
     "acquit-markdown": "0.1.0",
     "co": "4.6.0",
-    "eslint": "6.8.0",
+    "eslint": "7.x",
     "istanbul": "0.4.5",
     "mocha": "5.2.x",
     "mongoose": "7.0.0-rc0"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -788,4 +788,41 @@ describe('Discriminators work', () => {
       assert.equal(doc.child.child.fullName, 'Ben Skywalker');
     });
   });
+
+  it('can access parent virtuals from child subdocument (gh-64)', async function() {
+    const childSchema = new mongoose.Schema({ firstName: String });
+    childSchema.virtual('uri').get(function() {
+      // This `uri` virtual is in a subdocument, so in order to get the
+      // parent's `uri` you need to use this plugin's `parent()` function.
+  
+      const parent = this instanceof mongoose.Document
+        ? this.parent()
+        : mongooseLeanVirtuals.parent(this)
+      ;
+      return `${parent.uri}/child/gh-64-child`;
+    });
+  
+    const parentSchema = new mongoose.Schema({
+      child: childSchema
+    });
+    parentSchema.virtual('uri').get(function() {
+      return `/parent/gh-64-parent`;
+    });
+    
+    parentSchema.plugin(mongooseLeanVirtuals);
+    
+    const Parent = mongoose.model('gh64', parentSchema);
+    
+    const doc = { child: {} };
+  
+    await Parent.create(doc);
+  
+    let result = await Parent
+      .findOne()
+      .lean({ virtuals: true });
+    assert.equal(
+      result.child.uri,
+      '/parent/gh-64-parent/child/gh-64-child'
+    );  
+  });
 });


### PR DESCRIPTION
Fix #65
Fix #64

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#64 points out that, because mongoose-lean-virtual applies virtuals to child subdocs before their parents, that makes it tricky to use parent virtuals in child subdocs. This change was intentional with #28, and we can't change the subdoc traversal order without a backwards breaking change. But, given that `parent()` is the only way to get a subdocument's parent, mongoose-lean-virtuals _can_ apply virtuals in the `parent()` call to ensure the child subdoc gets the parent doc with virtuals applied.

This can create issues if a subdocument calls `parent()`, and then the parent tries to access one of the subdocument's virtuals. The subdocument virtual won't exist yet. But this case is hopefully unlikely.

I also bumped ESLint, fixed some lint warnings, added `parent()` to TypeScript type defs, and fixed #64 (also #66) because that's just a one-line fix.

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
