### PR TITLE
BREAKING CHANGE: rely on transforms over middleware to apply virtuals and add findOneAndReplace support

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "typescript": "5.x"
   },
   "peerDependencies": {
-    "mongoose": ">=5.11.10"
+    "mongoose": ">=8.0.0"
   },
   "author": "Valeri Karpov <val@karpov.io>",
   "license": "Apache 2.0",


### PR DESCRIPTION
Fix #75

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

#75 points out a significant issue in this plugin's functionality: Query `transform()`s run before middleware, so transform that changes the query shape causes this plugin to break. Fix the issue by making this plugin `unshift()` a transform to the front of the transforms array in `pre()`, which will ensure this plugin's transform will run before any user-specified transforms.

This change will require a 2.0.0 release because it may break some existing code.

@hasezoey can you please take a look at this one?

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
