### PR TITLE
fix: avoid unnecessarily setting populate virtuals to `[]` if query didn't have populate()

### DIFF
--- a/index.js
+++ b/index.js
@@ -218,19 +218,8 @@ function attachVirtualsToDoc(schema, doc, virtuals) {
       cur = cur[sp[j]];
     }
     let val = virtualType.applyGetters(cur[sp[sp.length - 1]], doc);
-    if (isPopulateVirtual(virtualType) && val === undefined) {
-      if (virtualType.options.justOne) {
-        val = null;
-      } else {
-        val = [];
-      }
-    }
     cur[sp[sp.length - 1]] = val;
   }
-}
-
-function isPopulateVirtual(virtualType) {
-  return virtualType.options && (virtualType.options.ref || virtualType.options.refPath);
 }
 
 module.exports.defaults = module.exports;


### PR DESCRIPTION
Fix #79
Re: Automattic/mongoose#10816

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**

Thanks for reporting. We originally added this behavior in https://github.com/mongoosejs/mongoose-lean-virtuals/commit/a9a8daac3f3d42623b6659c42e9ab809cf53445f for https://github.com/Automattic/mongoose/issues/10816, but this behavior looks to be no longer necessary. 

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->
